### PR TITLE
added support for Python 3.5 with patches for MSVC 2015

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,11 @@ environment:
     - TARGET_ARCH: x64
       CONDA_PY: 34
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/bufferopp.patch
+++ b/recipe/bufferopp.patch
@@ -1,0 +1,28 @@
+--- src\operation\buffer\BufferOp.cpp.orig	2015-11-13 12:18:57.302468000 +1000
++++ src\operation\buffer\BufferOp.cpp	2015-11-13 12:19:29.081764900 +1000
+@@ -17,7 +17,11 @@
+  * Last port: operation/buffer/BufferOp.java r378 (JTS-1.12)
+  *
+  **********************************************************************/
+-
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#endif
+ #include <algorithm>
+ #include <cmath>
+ 
+@@ -85,9 +89,9 @@
+ 	int maxPrecisionDigits)
+ {
+   const Envelope *env=g->getEnvelopeInternal();
+-  double envMax = std::max(
+-    std::max(fabs(env->getMaxX()), fabs(env->getMinX())),
+-    std::max(fabs(env->getMaxY()), fabs(env->getMinY()))
++  double envMax = max(
++    max(fabs(env->getMaxX()), fabs(env->getMinX())),
++    max(fabs(env->getMaxY()), fabs(env->getMinY()))
+   );
+ 
+   double expandByDistance = distance > 0.0 ? distance : 0.0;

--- a/recipe/lineintersector.patch
+++ b/recipe/lineintersector.patch
@@ -1,0 +1,14 @@
+--- src\algorithm\LineIntersector.cpp.orig	2013-08-26 01:10:29.000000000 +1000
++++ src\algorithm\LineIntersector.cpp	2015-11-13 11:49:38.744850900 +1000
+@@ -17,6 +17,11 @@
+  *
+  **********************************************************************/
+ 
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#endif
+ #include <geos/algorithm/LineIntersector.h>
+ #include <geos/algorithm/CGAlgorithms.h>
+ #include <geos/algorithm/HCoordinate.h>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,3 +40,4 @@ extra:
   recipe-maintainers:
     - ocefpaf
     - pelson
+    - gillins

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,13 @@ source:
     url: http://download.osgeo.org/geos/geos-{{ version }}.tar.bz2
     patches:
         - cmake.win.patch  # [win]
+        - lineintersector.patch  # [win and py35]
+        - wktwriter.patch  # [win and py35]
+        - bufferopp.patch  # [win and py35]
+        - offsetcurvebuilder.patch  # [win and py35]
+        - offsetcurvesetbuilder.patch  # [win and py35]
 
 build:
-    skip: True  # [py35 and win]
     number: 1
     features:
         - vc9  # [win and py27]

--- a/recipe/offsetcurvebuilder.patch
+++ b/recipe/offsetcurvebuilder.patch
@@ -1,0 +1,15 @@
+--- src\operation\buffer\OffsetCurveBuilder.cpp.orig	2013-08-26 01:10:29.000000000 +1000
++++ src\operation\buffer\OffsetCurveBuilder.cpp	2016-04-01 16:57:42.683796300 +1000
+@@ -18,6 +18,12 @@
+  *
+  **********************************************************************/
+ 
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#endif
++
+ #include <cassert>
+ #include <cmath>
+ #include <vector>

--- a/recipe/offsetcurvesetbuilder.patch
+++ b/recipe/offsetcurvesetbuilder.patch
@@ -1,0 +1,27 @@
+--- src\operation\buffer\OffsetCurvesetBuilder.cpp.orig	2013-08-26 01:10:29.000000000 +1000
++++ src\operation\buffer\OffsetCurvesetBuilder.cpp	2015-11-13 12:21:59.687233700 +1000
+@@ -17,7 +17,12 @@
+  * Last port: operation/buffer/OffsetCurveSetBuilder.java r378 (JTS-1.12)
+  *
+  **********************************************************************/
+-
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#define abs(x) std::abs(x)
++#endif
+ #include <geos/algorithm/CGAlgorithms.h>
+ #include <geos/algorithm/MinimumDiameter.h>
+ #include <geos/util/UnsupportedOperationException.h>
+@@ -333,8 +338,8 @@
+ 		return isTriangleErodedCompletely(ringCoord, bufferDistance);
+ 
+   const Envelope* env = ring->getEnvelopeInternal();
+-  double envMinDimension = std::min(env->getHeight(), env->getWidth());
+-  if (bufferDistance < 0.0 && 2 * std::abs(bufferDistance) > envMinDimension)
++  double envMinDimension = min(env->getHeight(), env->getWidth());
++  if (bufferDistance < 0.0 && 2 * abs(bufferDistance) > envMinDimension)
+       return true;
+ 
+ 	/**

--- a/recipe/wktwriter.patch
+++ b/recipe/wktwriter.patch
@@ -1,0 +1,14 @@
+--- src\io\WKTWriter.cpp.orig	2013-08-26 01:10:30.000000000 +1000
++++ src\io\WKTWriter.cpp	2015-11-13 12:15:42.758522700 +1000
+@@ -18,6 +18,11 @@
+  *
+  **********************************************************************/
+ 
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#endif
+ #include <geos/io/WKTWriter.h>
+ #include <geos/io/Writer.h>
+ #include <geos/io/CLocalizer.h>


### PR DESCRIPTION
Seems there are differences in the way the compiler interprets min()/max() that cause problems. Hopefully they can be removed when the next version of GEOS is released.

GDAL is dependent on this package so we will be able to update it to Python 3.5 next.
