### PR TITLE
Use the toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About geos
 
 Home: http://trac.osgeo.org/geos/
 
-Package license: LGPL
+Package license: LGPLv2.1
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
 
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
 
 # Problems with cartopy if the -m{32,64} flag is not defined.
 # See https://taskman.eionet.europa.eu/issues/14817.
+# - toolchain now defines this so we don't need to do anything
 
-MACHINE_TYPE=`uname -m`
-if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-  ARCH="-m64"
-elif [ ${MACHINE_TYPE} == 'x86_32' ]; then
-  ARCH="-m32"
-else
-  ARCH=""
+if [ "$(uname)" == "Darwin" ]
+then
+  export CXX="${CXX} -stdlib=libc++"
 fi
 
-CFLAGS=${ARCH} CPPFLAGS=${ARCH} CXXFLAGS=${ARCH} LDFLAGS=${ARCH} FFLAGS=${ARCH} \
-    ./configure --prefix=$PREFIX --without-jni
+./configure --prefix=$PREFIX
 
 make
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     build:
         - python  # [win]
         - msinttypes  # [win]
+        - toolchain
 
 test:
     commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
     home: http://trac.osgeo.org/geos/
-    license: LGPL
+    license: LGPLv2.1
     summary: Geometry Engine - Open Source
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
         - offsetcurvesetbuilder.patch  # [win and py35]
 
 build:
-    number: 1
+    number: 2
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
This PR changes the build to use the toolchain which fixes issues on OSX (see https://github.com/conda-forge/gdal-feedstock/issues/72). The resulting binaries are only linked against `libc++`.

It also tidies up the build script (-m64, -m32 flags now set by the toolchain, and --without-jni not recognised by the configure script).

It also closes https://github.com/conda-forge/geos-feedstock/issues/15
