### PR TITLE
Get Windows build working

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -25,4 +25,4 @@ if errorlevel 1 exit 1
 
 copy lib\*.exp %LIBRARY_LIB%\ || exit 1
 copy lib\*.lib %LIBRARY_LIB%\ || exit 1
-copy include\geos.h %LIBRARY_INC%\geos.h || exit 1
+copy ..\include\geos.h %LIBRARY_INC%\geos.h || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ source:
   fn:  geos-{{ version }}.tar.gz
   url: https://github.com/libgeos/libgeos/archive/{{ version }}.tar.gz
   sha256: 2215446cb734ecbcd487b53c27bfe373c3b3c36a897bdcf1fceab9adf84e10ee
+  patches:
+    - xmltester.cpp.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]

--- a/recipe/xmltester.cpp.patch
+++ b/recipe/xmltester.cpp.patch
@@ -1,0 +1,16 @@
+--- tests\xmltester\XMLTester.orig.cpp	2016-10-26 02:19:59.000000000 +1000
++++ tests\xmltester\XMLTester.cpp	2016-11-13 14:15:32.244247500 +1000
+@@ -292,6 +292,13 @@
+     return old_value;
+ }
+ 
++#if defined _MSC_VER && (_MSC_VER < 1900)
++double round(double number)
++{
++    return number < 0.0 ? ceil(number - 0.5) : floor(number + 0.5);
++}
++#endif
++
+ /*private*/
+ void
+ XMLTester::printTest(bool success, const std::string& expected_result, const std::string& actual_result, const util::Profile &prof)


### PR DESCRIPTION
This PR fixes the Windows build by providing `round()` where it isn't available - ie before VS 2015.

There was also an adjustment required to the location of `geos.h` now that the build happens one level down.

This is a follow on from #17 