### PR TITLE
Testing conda-build 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
       conda install conda-build=3 --yes
-    # conda config --add channels c3i_test --force --yes
+      conda config --add channels c3i_test --force
+      conda info
 
 script:
   - conda build ./recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ install:
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
+      conda install conda-build=3 --yes
+    # conda config --add channels c3i_test --force --yes
 
 script:
   - conda build ./recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
       conda install conda-build=3 --yes
-      conda config --add channels c3i_test --force
-      conda info
 
 script:
   - conda build ./recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,8 @@ install:
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
     - cmd: conda install conda-build=3 --yes
-    # - cmd: conda config --add channels c3i_test --force --yes
+    - cmd: conda config --add channels c3i_test --force
+     -cmd: conda info
 
 # Skip .NET project specific build phase.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,8 +57,6 @@ install:
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
     - cmd: conda install conda-build=3 --yes
-    - cmd: conda config --add channels c3i_test --force
-    - cmd: conda info
 
 # Skip .NET project specific build phase.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
     - cmd: run_conda_forge_build_setup
     - cmd: conda install conda-build=3 --yes
     - cmd: conda config --add channels c3i_test --force
-     -cmd: conda info
+    - cmd: conda info
 
 # Skip .NET project specific build phase.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,8 @@ install:
     # Configure the VM.
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
+    - cmd: conda install conda-build=3 --yes
+    # - cmd: conda config --add channels c3i_test --force --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,6 +57,9 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+conda install conda-build=3 --yes
+# conda config --add channels c3i_test --force --yes
+
 conda build /recipe_root --quiet || exit 1
 upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,6 +57,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+yum remove devtoolset-2-gcc devtoolset-2-gcc-c++ -y
 conda install conda-build=3 --yes
 conda config --add channels c3i_test --force
 conda info

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -58,7 +58,8 @@ conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
 conda install conda-build=3 --yes
-# conda config --add channels c3i_test --force --yes
+conda config --add channels c3i_test --force
+conda info
 
 conda build /recipe_root --quiet || exit 1
 upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -59,8 +59,6 @@ source run_conda_forge_build_setup
 
 yum remove devtoolset-2-gcc devtoolset-2-gcc-c++ -y
 conda install conda-build=3 --yes
-conda config --add channels c3i_test --force
-conda info
 
 conda build /recipe_root --quiet || exit 1
 upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,30 +18,6 @@ fi
 
 ./configure --prefix=$PREFIX
 
-make
-# See to be related to https://trac.osgeo.org/geos/ticket/299
-# Failing on OS X: https://travis-ci.org/conda-forge/geos-feedstock/builds/175667698
-# FAIL: geos_unit
-# ============================================================================
-# Testsuite summary for
-# ============================================================================
-# # TOTAL: 1
-# # PASS:  0
-# # SKIP:  0
-# # XFAIL: 0
-# # FAIL:  1
-# # XPASS: 0
-# # ERROR: 0
-# ============================================================================
-# See tests/unit/test-suite.log
-# ============================================================================
-# make[5]: *** [test-suite.log] Error 1
-# make[4]: *** [check-TESTS] Error 2
-# make[3]: *** [check-am] Error 2
-# make[2]: *** [check-recursive] Error 1
-# make[1]: *** [check-recursive] Error 1
-# make: *** [check] Error 2
-if [[ $(uname) == Linux ]]; then
-    make check
-fi
-make install
+make -j${CPU_COUNT} ${VERBOSE_AT}
+make check -j${CPU_COUNT} ${VERBOSE_AT}
+make install -j${CPU_COUNT} ${VERBOSE_AT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,18 +16,10 @@ elif [ ${MACHINE_TYPE} == 'x86_32' ]; then
   ARCH="-m32"
 fi
 
-if [ $(uname) == Darwin ]; then
-  export CC=clang
-  export CXX=clang++
-  export MACOSX_DEPLOYMENT_TARGET="10.9"
-  export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
-  export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
-fi
-
-
 ./configure --prefix=$PREFIX
 
 make
+# See to be related to https://trac.osgeo.org/geos/ticket/299
 # Failing on OS X: https://travis-ci.org/conda-forge/geos-feedstock/builds/175667698
 # FAIL: geos_unit
 # ============================================================================

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,8 +6,6 @@ if [ ! -f configure ]; then
   autoreconf -i --force
 fi
 
-export CFLAGS="-O2 -Wl,-S $CFLAGS"
-
 ARCH=""
 MACHINE_TYPE=$(uname -m)
 if [ ${MACHINE_TYPE} == 'x86_64' ]; then
@@ -16,6 +14,7 @@ elif [ ${MACHINE_TYPE} == 'x86_32' ]; then
   ARCH="-m32"
 fi
 
+export CFLAGS="-O2 -Wl,-S $CFLAGS"
 ./configure --prefix=$PREFIX
 
 make -j${CPU_COUNT} ${VERBOSE_AT}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,3 @@
-blas_impl:
-  - openblas
 c_compiler:                    # [win]
   - vs2008                     # [win]
   - vs2015                     # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,51 @@
+blas_impl:
+  - openblas
+c_compiler:                    # [win]
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+cxx_compiler:                  # [win]
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+CONDA_BUILD_SYSROOT:           # [osx]
+  - /opt/MacOSX10.9.sdk        # [osx]
+VERBOSE_AT:
+  - V=1
+VERBOSE_CM:
+  - VERBOSE=1
+macos_min_version:              # [osx]
+  - 10.9                        # [osx]
+macos_machine:                  # [osx]
+  - x86_64-apple-darwin13.4.0   # [osx]
+MACOSX_DEPLOYMENT_TARGET:       # [osx]
+  - 10.9                        # [osx]
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+# This differs from target_platform in that it determines what subdir the compiler
+#    will target, not what subdir the compiler package will be itself.
+#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
+#    code on win-64 miniconda.
+cross_compiler_target_platform:
+  - win-32                     # [win]
+  - win-64                     # [win]
+target_platform:
+  - win-64                     # [win]
+  - win-32                     # [win]
+vc:
+  - 9                          # [win]
+  - 14                         # [win]
+  - 14                         # [win]
+zip_keys:
+  -                             # [win]
+    - vc                        # [win]
+    - c_compiler                # [win]
+    - cxx_compiler              # [win]
+    - python                    # [win]
+  -                             # [osx]
+    - macos_min_version         # [osx]
+    - macos_machine             # [osx]
+    - MACOSX_DEPLOYMENT_TARGET  # [osx]
+    - CONDA_BUILD_SYSROOT       # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - msinttypes  # [win and vc<14]
     - cmake  # [win]
     - automake  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,24 +16,20 @@ build:
   number: 1
   skip: True  # [win and py36]
   features:
-    - vc9  # [win and py27]
-    - vc10  # [win and py34]
-    - vc14  # [win and py>=35]
+    - vc{{ vc }}  # [win]
+  run_exports:
+    # pretty poor backcompat.  SO name changes each release.
+    #   https://abi-laboratory.pro/tracker/timeline/geos/
+    - {{ pin_subpackage('geos', max_pin='x.x.x') }}
 
 requirements:
   build:
-    - python  # [win]
-    - msinttypes  # [win]
+    - msinttypes  # [win and vc<14]
     - cmake  # [win]
     - automake  # [not win]
     - libtool  # [not win]
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py>=35]
   run:
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py>=35]
+    - {{ compiler('c') }}
 
 test:
   commands:
@@ -58,3 +54,4 @@ extra:
     - ocefpaf
     - pelson
     - gillins
+    - msarahan

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,12 +24,11 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - msinttypes  # [win and vc<14]
     - cmake  # [win]
     - automake  # [not win]
     - libtool  # [not win]
-  run:
-    - {{ compiler('c') }}
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,8 @@ requirements:
 test:
   commands:
     - geos-config --version  # [not win]
-    - conda inspect linkages -p $PREFIX geos  # [not win]
-    - conda inspect objects -p $PREFIX geos  # [osx]
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: http://trac.osgeo.org/geos/


### PR DESCRIPTION
# Not ready for merging yet!
## Testing conda-build 3 and its new features

`geos` is a nice start b/c it does not depend on anything besides "build tools."
The plan is to work our way up `gdal`'s dependencies using this approach.

(Ping @gillins who is a maintainer of most of those dependencies too. In theory this would help us a lot with the constant inconsistencies we get when installing `gdal` with conda.)

Things we need to discuss:

- a single `conda_build_config.yaml` for all the feedstocks. This would condense a lot of what we do in 1 file like pining, `vc`/`compiler` selection (when using the `c3i_test channel` which hopefully will be available in `defaults` soon), `MACOSX_DEPLOYMENT_TARGET`, etc;
- how to override the defaults from the `conda_build_config.yaml` file, if we ever need to do that;
- the use of `c3i` packages.

I believe that moving to `conda-build 3` will simplify a lot of what we are doing and it will be worth in the long run. But it may take a while to get there :wink: 

@msarahan I am getting `Treating unknown selector 'vc' as if it was False.` on AppVeyor, see the [log](https://ci.appveyor.com/project/ocefpaf/geos-feedstock/build/1.0.42/job/oem8tjl3qcb7fl1d) error below. It is probably simple mistake on my part but I could not figure it out. `OS X` and `Linux` seems fine. It it unclear to me if it would be advisable to remove the `gcc ` package from the docker image.

I appreciate if someone with more experience with `conda-build 3` and the use of the tools available in `c3i` took a look at the logs.

```shell
Warning: Treating unknown selector 'vc' as if it was False.
Traceback (most recent call last):
  File "C:\Miniconda\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(main())
  File "C:\Miniconda\lib\site-packages\conda_build\cli\main_build.py", line 388, in main
    execute(sys.argv[1:])
  File "C:\Miniconda\lib\site-packages\conda_build\cli\main_build.py", line 379, in execute
    noverify=args.no_verify)
  File "C:\Miniconda\lib\site-packages\conda_build\api.py", line 185, in build
    need_source_download=need_source_download, config=config, variants=variants)
  File "C:\Miniconda\lib\site-packages\conda_build\build.py", line 1730, in build_tree
    bypass_env_check=True)
  File "C:\Miniconda\lib\site-packages\conda_build\render.py", line 602, in render_recipe
    get_package_variants(m))
  File "C:\Miniconda\lib\site-packages\conda_build\variants.py", line 365, in get_package_variants
    return dict_of_lists_to_list_of_dicts(combined_spec, config.platform)
  File "C:\Miniconda\lib\site-packages\conda_build\variants.py", line 258, in dict_of_lists_to_list_of_dicts
    for group in _get_zip_groups(combined):
  File "C:\Miniconda\lib\site-packages\conda_build\variants.py", line 230, in _get_zip_groups
    groups.append(_get_zip_dict_of_lists(combined_variant, group))
  File "C:\Miniconda\lib\site-packages\conda_build\variants.py", line 213, in _get_zip_dict_of_lists
    .format(used_keys[0], key))
ValueError: zip field vc length does not match zip field python length.  All zip fields within a group must be the same length.
```

Ping @msarahan, @mingwandroid, @jjhelmus, and @conda-forge/core 