### PR TITLE
make CMAKE_BUILD_TYPE=Release explicit

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,7 @@ echo #define GEOS_SVN_REVISION 4298 > geos_svn_revision.h
 cmake -G "NMake Makefiles" ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -D GEOS_BUILD_STATIC=OFF ^
+      -D CMAKE_BUILD_TYPE=Release ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - xmltester.cpp.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   run_exports:
     # pretty poor backcompat.  SO name changes each release.


### PR DESCRIPTION
GEOS builds are currently building Debug configuration on windows. #39 