### PR TITLE
Use modern features of Windows CMake build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,12 +1,10 @@
 mkdir build
 cd build
 
-echo #define GEOS_SVN_REVISION 4298 > geos_svn_revision.h
-
 :: Configure.
 cmake -G "NMake Makefiles" ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-      -D GEOS_BUILD_STATIC=OFF ^
+      -D BUILD_SHARED_LIBS=ON ^
       -D CMAKE_BUILD_TYPE=Release ^
       %SRC_DIR%
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,7 +2,7 @@ mkdir build
 cd build
 
 :: Configure.
-cmake -G "NMake Makefiles" ^
+cmake -G "Ninja" ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -D BUILD_SHARED_LIBS=ON ^
       -D CMAKE_BUILD_TYPE=Release ^
@@ -10,13 +10,13 @@ cmake -G "NMake Makefiles" ^
 if errorlevel 1 exit 1
 
 :: Build.
-cmake --build . --config Release
+ninja
 if errorlevel 1 exit 1
 
 :: Install.
-cmake --build . --config Release --target install
+ninja install
 if errorlevel 1 exit 1
 
 :: Test.
-ctest -C Release
+ctest -V --output-on-failure
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ build:
 
 requirements:
   build:
-    - msinttypes  # [win]
     - cmake  # [win]
     - ninja  # [win]
     - automake  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - xmltester.cpp.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     # pretty poor backcompat.  SO name changes each release.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   build:
     - msinttypes  # [win]
     - cmake  # [win]
+    - ninja  # [win]
     - automake  # [not win]
     - libtool  # [not win]
     - {{ compiler('c') }}


### PR DESCRIPTION
With the CMake build setup for Windows, there are a few stale lines that should be modernized:

- File `geos_svn_revision.h` no longer used
- `GEOS_BUILD_STATIC` was removed from a previous GEOS release. Use `BUILD_SHARED_LIBS=ON`.