### PR TITLE
Rewrite build.sh to use CMake instead of autotools

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,5 +18,5 @@ ninja install
 if errorlevel 1 exit 1
 
 :: Test.
-ctest -V --output-on-failure
+ctest --output-on-failure
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,48 +1,18 @@
 #!/bin/bash
 
-mv ${SRC_DIR}/README.md ${SRC_DIR}/README
+mkdir -p build && cd build
 
-if [ ! -f configure ]; then
-  autoreconf -i --force
-fi
+cmake ${CMAKE_ARGS} \
+      -D CMAKE_BUILD_TYPE=Release \
+      -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+      -D CMAKE_INSTALL_LIBDIR=lib \
+      -D BUILD_SHARED_LIBS=ON \
+      ${SRC_DIR}
 
-export CXXFLAGS="-O2 -Wl,-S ${CXXFLAGS}"
+make -j${CPU_COUNT} ${VERBOSE_CM}
 
-ARCH=""
-MACHINE_TYPE=$(uname -m)
-if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-  ARCH="-m64"
-elif [ ${MACHINE_TYPE} == 'x86_32' ]; then
-  ARCH="-m32"
-fi
-
-./configure --prefix=${PREFIX} --enable-static=no
-
-make -j${CPU_COUNT}
-# Failing on OS X: https://travis-ci.org/conda-forge/geos-feedstock/builds/175667698
-# FAIL: geos_unit
-# ============================================================================
-# Testsuite summary for
-# ============================================================================
-# # TOTAL: 1
-# # PASS:  0
-# # SKIP:  0
-# # XFAIL: 0
-# # FAIL:  1
-# # XPASS: 0
-# # ERROR: 0
-# ============================================================================
-# See tests/unit/test-suite.log
-# ============================================================================
-# make[5]: *** [test-suite.log] Error 1
-# make[4]: *** [check-TESTS] Error 2
-# make[3]: *** [check-am] Error 2
-# make[2]: *** [check-recursive] Error 1
-# make[1]: *** [check-recursive] Error 1
-# make: *** [check] Error 2
-if [[ $(uname) == Linux ]]; then
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
-    make check -j${CPU_COUNT}
+    ctest --output-on-failure
 fi
-fi
+
 make install -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 7e630507dcac9dc07565d249a26f06a15c9f5b0c52dd29129a0e3d381d7e382a
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   run_exports:
     # pretty poor backcompat.  SO name changes each release.
@@ -18,11 +18,9 @@ build:
 
 requirements:
   build:
-    - cmake  # [win]
+    - cmake
+    - make  # [not win]
     - ninja  # [win]
-    - automake  # [not win]
-    - libtool  # [not win]
-    - make  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
 


### PR DESCRIPTION
#### Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

#### Summary of changes
* Closes #54
* CMake is the only build tool supported for future versions of GEOS; see [RFC7](https://trac.osgeo.org/geos/wiki/RFC7)
* Don't rename README.md (why? bld.bat for Windows doesn't do this)
* Run ctest for all platforms
* Minor edit to bld.bat to run ctest without `-V`, same as build.sh