### PR TITLE
Rebuild to maybe fix os-x crash with shapely on python 3.10

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gillins @msarahan @mwtoews @ocefpaf @pelson @xylar
+* @akrherz @gillins @msarahan @mwtoews @ocefpaf @pelson @xylar

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ conda search geos --channel conda-forge
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
@@ -178,6 +179,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@akrherz](https://github.com/akrherz/)
 * [@gillins](https://github.com/gillins/)
 * [@msarahan](https://github.com/msarahan/)
 * [@mwtoews](https://github.com/mwtoews/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: a8148eec9636814c8ab0f8f5266ce6f9b914ed65b0d083fc43bb0bbb01f83648
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     # pretty poor backcompat.  SO name changes each release.
@@ -42,6 +42,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - akrherz
     - ocefpaf
     - pelson
     - gillins


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Been attempting to track down a crash in the combo of conda-forge os-x python 3.10 + shapely + geos + libffi, see Toblerity/Shapely#1227

perhaps it would be good to arbitrarily rebuild geos and see if the troubles magically go away :/  I also added myself as a maintainer.